### PR TITLE
Extra Chat widget for Slack deleted

### DIFF
--- a/index.html
+++ b/index.html
@@ -431,7 +431,6 @@
 
 <script type="text/javascript" src="https://js.bepaid.by/begateway-1-latest.min.js"></script>
 <script type="text/javascript" src="dl_doika-1/mpa/mpa-script.js"></script>
-<script src="slackChatWidget/slackWidgetLoader.js"></script>
 
 </body>
 


### PR DESCRIPTION
Excessive Chat widget for Slack in the bottom of the page was deleted.
Only Chat widget for Slack in the head section of the page, line 49, left.